### PR TITLE
🐛 fix(timezone): Fix timezone to Europe/Paris

### DIFF
--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -21,6 +21,7 @@ services:
     environment:
       DAILY_LIMIT_PER_HOST: 10 # If set to 0 => no LIMIT
       DATABASE_URL: mysql+aiomysql://ecoindex:ecoindex@db/ecoindex?charset=utf8mb4
+      TZ: Europe/Paris
     depends_on:
       - db
     volumes:


### PR DESCRIPTION
This setting is now explicit in the docker compose configuration file. By default is set to `Europe/Paris`

Fixes https://github.com/cnumr/EcoIndex/issues/124